### PR TITLE
upgpkg: python-databricks-cli 0.9.1-2: remove python-libconfigparser

### DIFF
--- a/python-databricks-cli/.SRCINFO
+++ b/python-databricks-cli/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = python-databricks-cli
 	pkgdesc = open source tool which provides an easy to use interface to the Databricks platform
 	pkgver = 0.9.1
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/databricks/databricks-cli
 	arch = x86_64
 	license = Apache-2.0
@@ -12,7 +12,6 @@ pkgbase = python-databricks-cli
 	depends = python-requests
 	depends = python-tabulate
 	depends = python-six
-	depends = python-libconfigparser
 	source = python-databricks-cli-0.9.1::https://github.com/databricks/databricks-cli/archive/0.9.1.tar.gz
 	sha256sums = 6b7748da9595b818618ce3810647f900304219122114472e6653c4ffcd302537
 

--- a/python-databricks-cli/PKGBUILD
+++ b/python-databricks-cli/PKGBUILD
@@ -2,14 +2,13 @@
 
 pkgname=python-databricks-cli
 pkgver=0.9.1
-pkgrel=1
+pkgrel=2
 pkgdesc='open source tool which provides an easy to use interface to the
 Databricks platform'
 arch=('x86_64')
 url='https://github.com/databricks/databricks-cli'
 license=('Apache-2.0')
-depends=('python' 'python-click' 'python-requests' 'python-tabulate'
-    'python-six' 'python-libconfigparser')
+depends=('python' 'python-click' 'python-requests' 'python-tabulate' 'python-six')
 optdepends=()
 makedepends=('python' 'python-setuptools')
 source=("$pkgname-$pkgver::https://github.com/databricks/databricks-cli/archive/$pkgver.tar.gz")


### PR DESCRIPTION
The AUR package python-libconfigparser was renamed to python-configparser in PRQ#18283
(https://lists.archlinux.org/pipermail/aur-requests/2020-March/038387.html). For Python 3.8 currently used in Arch Linux this package should not be necessary at all since it is a backport of the module that Python offers natively since version 3.6.