### PR TITLE
[triangle] Fix triangle.h

### DIFF
--- a/archimedes-tools/.SRCINFO
+++ b/archimedes-tools/.SRCINFO
@@ -1,14 +1,16 @@
 pkgbase = archimedes-tools
 	pkgdesc = Archimedes is a set of tools, including mesh generators, for performing unstructured finite element simulations
 	pkgver = 1.6
-	pkgrel = 6
+	pkgrel = 7
 	url = http://www.cs.cmu.edu/~quake/archimedes.html
 	arch = i686
 	arch = x86_64
 	license = custom
 	makedepends = libx11
 	source = http://www.netlib.org/voronoi/triangle.zip
+	source = triangle_definitions.patch
 	md5sums = 10aff8d7950f5e0e2fb6dd2e340be2c9
+	md5sums = 98844d1b1d9de73101b660412132cd07
 
 pkgname = triangle
 	pkgdesc = A Two-Dimensional Quality Mesh Generator and Delaunay Triangulator.

--- a/archimedes-tools/PKGBUILD
+++ b/archimedes-tools/PKGBUILD
@@ -13,7 +13,7 @@ license=('custom')
 source=('http://www.netlib.org/voronoi/triangle.zip'
         'triangle_definitions.patch')
 md5sums=('10aff8d7950f5e0e2fb6dd2e340be2c9'
-         '506a271941d0b2552f5931e80e52d14f')
+         '98844d1b1d9de73101b660412132cd07')
 makedepends=('libx11')
 
 prepare() {

--- a/archimedes-tools/PKGBUILD
+++ b/archimedes-tools/PKGBUILD
@@ -5,14 +5,20 @@
 pkgbase=archimedes-tools
 pkgname=('triangle' 'showme')
 pkgver=1.6
-pkgrel=6
+pkgrel=7
 arch=('i686' 'x86_64')
 url='http://www.cs.cmu.edu/~quake/archimedes.html'
 pkgdesc='Archimedes is a set of tools, including mesh generators, for performing unstructured finite element simulations'
 license=('custom')
-source=('http://www.netlib.org/voronoi/triangle.zip')
-md5sums=('10aff8d7950f5e0e2fb6dd2e340be2c9')
+source=('http://www.netlib.org/voronoi/triangle.zip'
+        'triangle_definitions.patch')
+md5sums=('10aff8d7950f5e0e2fb6dd2e340be2c9'
+         '506a271941d0b2552f5931e80e52d14f')
 makedepends=('libx11')
+
+prepare() {
+  patch < ../triangle_definitions.patch triangle.h
+}
 
 build(){
   gcc ${CFLAGS} -o triangle triangle.c -lm
@@ -21,6 +27,7 @@ build(){
 
   gcc ${CFLAGS} -o showme showme.c -lX11
 }
+
 
 package_triangle() {
   url='http://www.cs.cmu.edu/~quake/triangle.html'

--- a/archimedes-tools/PKGBUILD
+++ b/archimedes-tools/PKGBUILD
@@ -28,7 +28,6 @@ build(){
   gcc ${CFLAGS} -o showme showme.c -lX11
 }
 
-
 package_triangle() {
   url='http://www.cs.cmu.edu/~quake/triangle.html'
   pkgdesc='A Two-Dimensional Quality Mesh Generator and Delaunay Triangulator.'

--- a/archimedes-tools/triangle_definitions.patch
+++ b/archimedes-tools/triangle_definitions.patch
@@ -1,0 +1,17 @@
+--- triangle.h.orig	2020-06-02 10:36:40.378051634 +0200
++++ triangle.h.new	2020-06-02 10:46:13.153369802 +0200
+@@ -248,6 +248,14 @@
+ /*                                                                           */
+ /*****************************************************************************/
+ 
++#ifdef SINGLE
++#define REAL float
++#else /* not SINGLE */
++#define REAL double
++#endif /* not SINGLE */
++
++#define VOID int
++
+ struct triangulateio {
+   REAL *pointlist;                                               /* In / out */
+   REAL *pointattributelist;                                      /* In / out */

--- a/archimedes-tools/triangle_definitions.patch
+++ b/archimedes-tools/triangle_definitions.patch
@@ -1,16 +1,20 @@
---- triangle.h.orig	2020-06-02 10:36:40.378051634 +0200
-+++ triangle.h.new	2020-06-02 10:46:13.153369802 +0200
-@@ -248,6 +248,14 @@
+--- triangle.h.orig	2020-06-02 12:09:50.338390608 +0200
++++ triangle.h.new	2020-06-02 12:10:38.335508560 +0200
+@@ -248,6 +248,18 @@
  /*                                                                           */
  /*****************************************************************************/
  
++#ifndef REAL
 +#ifdef SINGLE
 +#define REAL float
 +#else /* not SINGLE */
 +#define REAL double
 +#endif /* not SINGLE */
++#endif
 +
++#ifndef VOID
 +#define VOID int
++#endif
 +
  struct triangulateio {
    REAL *pointlist;                                               /* In / out */


### PR DESCRIPTION
I have revisited the versions of triangle and its inclusion in PETSc.
The version provided by PETSc is outdated. The vanilla version works, but requires the following changes to the header. Otherwise, REAL and VOID are not defined.