### PR TITLE
[Fix #44] update makedepends of python-dm-tree and its git alternative

### DIFF
--- a/python-dm-tree-git/.SRCINFO
+++ b/python-dm-tree-git/.SRCINFO
@@ -1,12 +1,13 @@
 pkgbase = python-dm-tree-git
 	pkgdesc = tree is a library for working with nested data structures
-	pkgver = r44.65ce9e4
+	pkgver = r49.63e7c35
 	pkgrel = 1
 	url = https://tree.readthedocs.io
 	arch = any
 	license = Apache-2.0
 	makedepends = python
 	makedepends = python-setuptools
+	makedepends = bazel
 	depends = python
 	depends = python-six
 	provides = python-dm-tree

--- a/python-dm-tree-git/PKGBUILD
+++ b/python-dm-tree-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 
 pkgname=python-dm-tree-git
-pkgver=r44.65ce9e4
+pkgver=r49.63e7c35
 pkgrel=1
 pkgdesc='tree is a library for working with nested data structures'
 arch=('any')
@@ -9,7 +9,7 @@ url='https://tree.readthedocs.io'
 license=('Apache-2.0')
 depends=(python python-six)
 optdepends=()
-makedepends=(python python-setuptools)
+makedepends=(python python-setuptools bazel)
 provides=('python-dm-tree')
 conflicts=('python-dm-tree')
 source=("$pkgname::git+https://github.com/deepmind/tree")

--- a/python-dm-tree/.SRCINFO
+++ b/python-dm-tree/.SRCINFO
@@ -1,12 +1,13 @@
 pkgbase = python-dm-tree
 	pkgdesc = tree is a library for working with nested data structures
 	pkgver = 0.1.4
-	pkgrel = 1
+	pkgrel = 2
 	url = https://tree.readthedocs.io
 	arch = any
 	license = Apache-2.0
 	makedepends = python
 	makedepends = python-setuptools
+	makedepends = bazel
 	depends = python
 	depends = python-six
 	source = python-dm-tree-0.1.4::https://pypi.org/packages/source/d/dm-tree/dm-tree-0.1.4.tar.gz

--- a/python-dm-tree/PKGBUILD
+++ b/python-dm-tree/PKGBUILD
@@ -2,14 +2,14 @@
 
 pkgname=python-dm-tree
 pkgver=0.1.4
-pkgrel=1
+pkgrel=2
 pkgdesc='tree is a library for working with nested data structures'
 arch=('any')
 url='https://tree.readthedocs.io'
 license=('Apache-2.0')
 depends=(python python-six)
 optdepends=()
-makedepends=(python python-setuptools)
+makedepends=(python python-setuptools bazel)
 source=("$pkgname-$pkgver::https://pypi.org/packages/source/d/dm-tree/dm-tree-${pkgver}.tar.gz")
 sha256sums=('c4477ba8fee2fd7113ce0ef48a5bcf4f881100dcf5e609853368bbab96f4095e')
 


### PR DESCRIPTION
Update `makedepends` of python-dm-tree and its git alternative: [bazel](https://www.archlinux.org/packages/community/x86_64/bazel/).

Resolve #44 