### PR TITLE
[orocos-kdl-python-git] use the right python interpreter

### DIFF
--- a/orocos-kdl-python-git/.SRCINFO
+++ b/orocos-kdl-python-git/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = orocos-kdl-python-git
 	pkgdesc = The Kinematics and Dynamics Library is a framework for modelling and computation of kinematic chains (Python binding)
 	pkgver = r931.546d04d
-	pkgrel = 2
+	pkgrel = 3
 	url = https://www.orocos.org/kdl
 	arch = i686
 	arch = x86_64

--- a/orocos-kdl-python-git/PKGBUILD
+++ b/orocos-kdl-python-git/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=orocos-kdl-python-git
 pkgver=r931.546d04d
-pkgrel=2
+pkgrel=3
 pkgdesc="The Kinematics and Dynamics Library is a framework for modelling and computation of kinematic chains (Python binding)"
 arch=('i686' 'x86_64')
 url="https://www.orocos.org/kdl"
@@ -28,6 +28,7 @@ build() {
 
   cmake -DCMAKE_INSTALL_PREFIX=/usr \
         -DBUILD_PYKDL_PYBIND11=OFF \
+        -DPYTHON_EXECUTABLE=/usr/bin/python \
         .
 
   make


### PR DESCRIPTION
When python2 is installed, cmake will prefer the python2 interpreter over the python3 interpreter.
This ultimately leads to a build error because `sipconfig.py` is not found (because only python-sip is a dependency but not python2-sip).

Adding a line fixes this by always using Python 3 to build.