### PR TITLE
[vgrep] fix small hurdles and modernize according to current guidelines

### DIFF
--- a/vgrep/.SRCINFO
+++ b/vgrep/.SRCINFO
@@ -1,11 +1,11 @@
 pkgbase = vgrep
 	pkgdesc = Reimpementation of the ancient cgvg perl scripts
 	pkgver = 2.4.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/vrothberg/vgrep
 	arch = x86_64
 	arch = i686
-	license = GPLv3
+	license = GPL3
 	depends = go
 	source = vgrep-2.4.0.tar.gz::https://github.com/vrothberg/vgrep/archive/v2.4.0.tar.gz
 	sha256sums = d0dd594156638158f7163d37169dd02e3a82eabfa6c8f57d6eb1dfa89c669c03

--- a/vgrep/PKGBUILD
+++ b/vgrep/PKGBUILD
@@ -1,35 +1,35 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 # Contributor: Darshit Shah <darnir@gmail.com>
+# Contributor: Jonas Malaco <jonas@protocubo.io>
 
 pkgname=vgrep
 pkgver=2.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Reimpementation of the ancient cgvg perl scripts"
 arch=('x86_64' 'i686')
-license=('GPLv3')
+license=('GPL3')
 depends=('go')
 url="https://github.com/vrothberg/vgrep"
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/vrothberg/${pkgname}/archive/v${pkgver}.tar.gz")
 sha256sums=('d0dd594156638158f7163d37169dd02e3a82eabfa6c8f57d6eb1dfa89c669c03')
 
-prepare() {
-  mkdir $srcdir/{bin,pkg,src}
-  mv $srcdir/${pkgname}-${pkgver}/ $srcdir/src/
-  cd $srcdir/src/$pkgname-$pkgver
-}
-
 build() {
-  cd $srcdir/src/$pkgname-$pkgver
-  export GOPATH=$srcdir
-  go get ./...
-  make release
+  cd "$pkgname-$pkgver"
+  mkdir -p build/
+
+  export CGO_CPPFLAGS="${CPPFLAGS}"
+  export CGO_CFLAGS="${CFLAGS}"
+  export CGO_CXXFLAGS="${CXXFLAGS}"
+  export CGO_LDFLAGS="${LDFLAGS}"
+  export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+
+  go build -o build -ldflags "-linkmode=external -X main.version=${pkgver}" ./...
 }
 
 package() {
-  cd "$srcdir/src/$pkgname-$pkgver"
+  cd "$pkgname-$pkgver"
 
-  install -m755 -d "${pkgdir}/usr/bin"
-  install -m755 -t "${pkgdir}/usr/bin/" build/vgrep
+  install -Dm755 build/$pkgname "$pkgdir"/usr/bin/$pkgname
 }
 
 # vim: ts=2:sw=2:et


### PR DESCRIPTION
The current version of the package makes everything in `src/pkg/mod/*/*` read only, even for the owner, resulting in an unnecessary, if simple to resolve, hurdle when removing them (for example, for `--cleanbuild`).  Additionally, successive rebuilds are not possible due to a missing `-p` flag in the first execution of `mkdir`.

In order to fix the first problem I resorted to the Arch [Go package guidelines](https://wiki.archlinux.org/index.php/Go_package_guidelines), because I'm not familiar with building Go programs.  This made me notice a few aspects of the package that could be brought up to the current standard and, arguably though I agree with the guidelines), simplified.

Go-specific changes:

- do not create `bin` / `pkg` / `src` directories
- ensure the build system flags are used, instead of the Makefile ones
- do not use `GOPATH` since it is no longer necessary

Other changes:

- remove `i686` arch since it is no longer supported by ArchLinux
- make the license identifier match the corresponding license directory  name in `/usr/share/licenses/common/`
- create (if necessary) the target directory and copy the binary in a single step