### PR TITLE
[python-cfclient] additional make dep.

### DIFF
--- a/python-cfclient/.SRCINFO
+++ b/python-cfclient/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = python-cfclient
 	pkgdesc = Host applications and library for Crazyflie written in Python.
 	pkgver = 2020.02
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/bitcraze/crazyflie-clients-python
 	arch = any
 	license = GPL-2.0

--- a/python-cfclient/PKGBUILD
+++ b/python-cfclient/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=python-cfclient
 pkgver=2020.02
-pkgrel=1
+pkgrel=2
 pkgdesc='Host applications and library for Crazyflie written in Python.'
 arch=('any')
 url='https://github.com/bitcraze/crazyflie-clients-python'


### PR DESCRIPTION
`python-cx_freeze` is required for `setup.py` in `python-cfclient`.

**Warning**: build fails with `python-cx_freeze=6.2`. The fix will be included in the next release. Downgrading to [python-cx_freeze=6.1](https://archive.archlinux.org/packages/p/python-cx_freeze/python-cx_freeze-6.1-1-x86_64.pkg.tar.zst) is a workaround. I do not know how you can formulate something like `makedepends=(python-cx_freeze=6.1 or python-cx_freeze>6.2)`.