### PR TITLE
[python-cfclient] add udev rules as opt. dependencies

### DIFF
--- a/python-cfclient/.SRCINFO
+++ b/python-cfclient/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = python-cfclient
 	pkgdesc = Host applications and library for Crazyflie written in Python.
 	pkgver = 2020.02
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/bitcraze/crazyflie-clients-python
 	arch = any
 	license = GPL-2.0
@@ -17,6 +17,8 @@ pkgbase = python-cfclient
 	depends = python-quamash
 	depends = python-qtm
 	depends = python-pyqt5
+	optdepends = crazyflie-udev
+	optdepends = crazyradio-udev
 	source = python-cfclient-2020.02.tar.gz::https://github.com/bitcraze/crazyflie-clients-python/archive/2020.02.tar.gz
 	sha256sums = aec8218634ad2ef0ab4a5c2bf9d3e470b6faf959b508199f155cb9497597f3b4
 

--- a/python-cfclient/PKGBUILD
+++ b/python-cfclient/PKGBUILD
@@ -2,13 +2,14 @@
 
 pkgname=python-cfclient
 pkgver=2020.02
-pkgrel=2
+pkgrel=3
 pkgdesc='Host applications and library for Crazyflie written in Python.'
 arch=('any')
 url='https://github.com/bitcraze/crazyflie-clients-python'
 license=('GPL-2.0')
 depends=(python python-cflib python-appdirs python-pyzmq python-pyqtgraph
     python-pyaml python-quamash python-qtm python-pyqt5)
+optdepends=(crazyflie-udev crazyradio-udev)
 makedepends=(python python-setuptools python-cx_freeze)
 source=("$pkgname-$pkgver.tar.gz::https://github.com/bitcraze/crazyflie-clients-python/archive/$pkgver.tar.gz")
 sha256sums=('aec8218634ad2ef0ab4a5c2bf9d3e470b6faf959b508199f155cb9497597f3b4')


### PR DESCRIPTION
according to the comments in https://aur.archlinux.org/packages/crazyflie-udev