### PR TITLE
Add missing dependency on npm

### DIFF
--- a/python-vispy/.SRCINFO
+++ b/python-vispy/.SRCINFO
@@ -1,12 +1,13 @@
 pkgbase = python-vispy
 	pkgdesc = A high-performance interactive 2D/3D data visualization library.
 	pkgver = 0.6.6
-	pkgrel = 1
+	pkgrel = 2
 	url = http://vispy.org
 	arch = any
 	license = BSD
 	makedepends = python-setuptools
 	makedepends = cython
+	makedepends = npm
 	depends = python-numpy
 	optdepends = pyside2: a possible backend
 	optdepends = python-pyqt5: a possible backend

--- a/python-vispy/PKGBUILD
+++ b/python-vispy/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=python-vispy
 pkgver=0.6.6
-pkgrel=1
+pkgrel=2
 pkgdesc='A high-performance interactive 2D/3D data visualization library.'
 arch=('any')
 url='http://vispy.org'

--- a/python-vispy/PKGBUILD
+++ b/python-vispy/PKGBUILD
@@ -10,7 +10,7 @@ arch=('any')
 url='http://vispy.org'
 license=('BSD')
 depends=('python-numpy')
-makedepends=('python-setuptools' 'cython')
+makedepends=('python-setuptools' 'cython' 'npm')
 optdepends=('pyside2: a possible backend'
             'python-pyqt5: a possible backend')
 _pkgname=vispy


### PR DESCRIPTION
I was trying to install python-vispy and this crashed with
```
/var/tmp/pamac-build/python-vispy/src/vispy-0.6.6/.eggs/setuptools_scm-4.1.2-py3.8.egg/setuptools_scm/version.py:202: UserWarning: meta invoked without explicit configuration, will use defaults where required.
  warnings.warn(
`npm` unavailable.  If you're running this command using sudo, make sure `npm` is available to sudo
rebuilding js and css failed
missing files: ['/var/tmp/pamac-build/python-vispy/src/vispy-0.6.6/vispy/static/extension.js', '/var/tmp/pamac-build/python-vispy/src/vispy-0.6.6/vispy/static/index.js']
Traceback (most recent call last):
  File "setup.py", line 179, in <module>
    setup(
  File "/usr/lib/python3.8/site-packages/setuptools/__init__.py", line 153, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python3.8/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.8/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.8/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/usr/lib/python3.8/distutils/command/build.py", line 135, in run
    self.run_command(cmd_name)
  File "/usr/lib/python3.8/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python3.8/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "setup.py", line 84, in run
    raise e
  File "setup.py", line 75, in run
    self.distribution.run_command('jsdeps')
  File "/usr/lib/python3.8/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "setup.py", line 167, in run
    raise ValueError(msg)
ValueError: Missing file: /var/tmp/pamac-build/python-vispy/src/vispy-0.6.6/vispy/static/extension.js
npm is required to build a development version of a widget extension
==> ERROR: A failure occurred in build().
    Aborting...
```