### PR TITLE
[half] Fix a bug in the half.hpp include file not enabling F16C intrinsics correctly when the architecture supports it.

### DIFF
--- a/half/.SRCINFO
+++ b/half/.SRCINFO
@@ -1,12 +1,14 @@
 pkgbase = half
 	pkgdesc = Half-precision floating-point library
 	pkgver = 2.1.0
-	pkgrel = 2
+	pkgrel = 3
 	url = http://half.sourceforge.net/
 	arch = x86_64
 	license = MIT
 	source = half-2.1.0.zip::https://sourceforge.net/projects/half/files/half/2.1.0/half-2.1.0.zip/download
+	source = f16c_fix.patch
 	sha256sums = ad1788afe0300fa2b02b0d1df128d857f021f92ccf7c8bddd07812685fa07a25
+	sha256sums = 2f55340a7e2f654487a0ce6467068a142e00a1fa10a118c859a3cdba6070d8c6
 
 pkgname = half
 

--- a/half/PKGBUILD
+++ b/half/PKGBUILD
@@ -20,6 +20,7 @@ sha256sums=(
 prepare() {
     # Fix a bug in the half.hpp include file not enabling F16C intrinsics
     # correctly when the architecture supports it
+    # https://github.com/acxz/pkgbuilds/issues/94
     patch -p0 ${srcdir}/include/half.hpp < f16c_fix.patch
 }
 

--- a/half/PKGBUILD
+++ b/half/PKGBUILD
@@ -1,15 +1,27 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=half
 pkgver=2.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Half-precision floating-point library"
 url="http://half.sourceforge.net/"
 arch=(x86_64)
 license=('MIT')
 makedepends=()
 depends=()
-source=("${pkgname}-${pkgver}.zip::https://sourceforge.net/projects/${pkgname}/files/${pkgname}/${pkgver}/${pkgname}-${pkgver}.zip/download")
-sha256sums=("ad1788afe0300fa2b02b0d1df128d857f021f92ccf7c8bddd07812685fa07a25")
+source=(
+    "${pkgname}-${pkgver}.zip::https://sourceforge.net/projects/${pkgname}/files/${pkgname}/${pkgver}/${pkgname}-${pkgver}.zip/download"
+    "f16c_fix.patch"
+)
+sha256sums=(
+    "ad1788afe0300fa2b02b0d1df128d857f021f92ccf7c8bddd07812685fa07a25"
+    "2f55340a7e2f654487a0ce6467068a142e00a1fa10a118c859a3cdba6070d8c6"
+)
+
+prepare() {
+    # Fix a bug in the half.hpp include file not enabling F16C intrinsics
+    # correctly when the architecture supports it
+    patch -p0 ${srcdir}/include/half.hpp < f16c_fix.patch
+}
 
 package() {
     mkdir -p ${pkgdir}/usr/include/half

--- a/half/f16c_fix.patch
+++ b/half/f16c_fix.patch
@@ -1,0 +1,23 @@
+--- upstream/half.hpp	2020-12-22 10:47:45.583725510 +0100
++++ f16c_fix/half.hpp	2020-12-22 10:48:21.917419594 +0100
+@@ -266,10 +266,6 @@
+ #if HALF_ENABLE_CPP11_HASH
+ 	#include <functional>
+ #endif
+-#if HALF_ENABLE_F16C_INTRINSICS
+-	#include <immintrin.h>
+-#endif
+-
+ 
+ #ifndef HALF_ENABLE_F16C_INTRINSICS
+ 	/// Enable F16C intruction set intrinsics.
+@@ -280,6 +276,9 @@
+ 	/// Unless predefined it will be enabled automatically when the `__F16C__` symbol is defined, which some compilers do on supporting platforms.
+ 	#define HALF_ENABLE_F16C_INTRINSICS __F16C__
+ #endif
++#if HALF_ENABLE_F16C_INTRINSICS
++	#include <immintrin.h>
++#endif
+ 
+ #ifdef HALF_DOXYGEN_ONLY
+ /// Type for internal floating-point computations.


### PR DESCRIPTION
Bug:
The immintrin.h header will not be included if ```HALF_ENABLE_F16C_INTRINSICS``` wasn't provided manually.
```HALF_ENABLE_F16C_INTRINSICS``` though will be set to ```__F16C__``` which compilers (GCC) provide if a proper ```-march``` flag is given, so this enables the intrinsics without having included the header above.
Compiler errors ensue because things like ```_mm_set_ss``` are not declared.

PR fixes this by putting the include directive after ```HALF_ENABLE_F16C_INTRINSICS``` being set to ```__F16C__``` which the compiler should set.

Issue mailed to upstream, bug is known but no bugfix release out yet.
Keep a look out for next release where this will hopefully be fixed.

Patches #94 