### PR TITLE
ogre-1.9 needs boost-libs

### DIFF
--- a/ogre-1.9/.SRCINFO
+++ b/ogre-1.9/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ogre-1.9
 	pkgdesc = Scene-oriented, flexible 3D engine written in C++
 	pkgver = 1.9.1
-	pkgrel = 4
+	pkgrel = 5
 	url = https://www.ogre3d.org
 	arch = x86_64
 	license = custom:MIT
@@ -23,6 +23,7 @@ pkgbase = ogre-1.9
 	depends = sdl2
 	depends = glu
 	depends = tinyxml
+	depends = boost-libs
 	provides = ogre=1.9
 	provides = ogre-docs=1.9
 	source = https://github.com/OGRECave/ogre/archive/v1.9.1.tar.gz

--- a/ogre-1.9/PKGBUILD
+++ b/ogre-1.9/PKGBUILD
@@ -4,13 +4,14 @@
 pkgbase=ogre-1.9
 pkgname=('ogre-1.9' 'ogre-docs-1.9')
 pkgver=1.9.1
-pkgrel=4
+pkgrel=5
 pkgdesc='Scene-oriented, flexible 3D engine written in C++'
 arch=('x86_64')
 url='https://www.ogre3d.org'
 license=('custom:MIT')
 depends=('freeimage' 'freetype2' 'libxaw' 'libxrandr' 'openexr'
-         'nvidia-cg-toolkit' 'zziplib' 'sdl2' 'glu' 'tinyxml')
+         'nvidia-cg-toolkit' 'zziplib' 'sdl2' 'glu' 'tinyxml'
+         'boost-libs')
 makedepends=('cmake' 'doxygen' 'graphviz' 'ttf-dejavu' 'mesa' 'python' 'swig' 'systemd')
 provides=('ogre=1.9' 'ogre-docs=1.9')
 source=("https://github.com/OGRECave/ogre/archive/v${pkgver}.tar.gz")


### PR DESCRIPTION
I noticed that new boost 1.75 broke Gazebo. Gazebo depends on `ogre-1.9` which in turn seems to depend on `libboost_thread.so.1.75.0`, even I could not find it on ogre build instructions:
```
$ readelf -d elfbin /usr/lib/libOgre* | grep boost
readelf: Error: 'elfbin': No such file
0x0000000000000001 (NEEDED)             Shared library: [libboost_thread.so.1.75.0]
 0x0000000000000001 (NEEDED)             Shared library: [libboost_thread.so.1.75.0]
 0x0000000000000001 (NEEDED)             Shared library: [libboost_thread.so.1.75.0]
 0x0000000000000001 (NEEDED)             Shared library: [libboost_thread.so.1.75.0]
 0x0000000000000001 (NEEDED)             Shared library: [libboost_thread.so.1.75.0]
 0x0000000000000001 (NEEDED)             Shared library: [libboost_thread.so.1.75.0]
```

I added directly `boost-libs`, because:
```
$ pacman -Ql boost-libs | grep 'libboost_thread*.so'
boost-libs /usr/lib/libboost_thread.so
boost-libs /usr/lib/libboost_thread.so.1.75.0
```
Is it better to add `libboost_thread.so` as a dep or the whole `boost-libs`? [`boost-libs` provides `libboost_thread.so`](https://archlinux.org/packages/extra/x86_64/boost-libs/) , but I do not know what is the best practice.

