### PR TITLE
Replace tinyxml dependency with tinyxml2

### DIFF
--- a/sdformat/.SRCINFO
+++ b/sdformat/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = sdformat
 	pkgdesc = SDF Converter for gazebo
 	pkgver = 10.1.0
-	pkgrel = 1
+	pkgrel = 2
 	url = http://sdformat.org/
 	arch = i686
 	arch = x86_64
@@ -12,7 +12,7 @@ pkgbase = sdformat
 	makedepends = ignition-tools
 	makedepends = ruby
 	depends = boost
-	depends = tinyxml
+	depends = tinyxml2
 	depends = ignition-math>=6
 	depends = python-psutil
 	depends = urdfdom

--- a/sdformat/PKGBUILD
+++ b/sdformat/PKGBUILD
@@ -1,12 +1,12 @@
 #Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=sdformat
 pkgver=10.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="SDF Converter for gazebo"
 arch=('i686' 'x86_64')
 url="http://sdformat.org/"
 license=('Apache')
-depends=('boost' 'tinyxml' 'ignition-math>=6' 'python-psutil' 'urdfdom')
+depends=('boost' 'tinyxml2' 'ignition-math>=6' 'python-psutil' 'urdfdom')
 makedepends=('cmake' 'doxygen' 'ignition-cmake' 'ignition-tools' 'ruby')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/osrf/${pkgname}/archive/${pkgname}10_${pkgver}.tar.gz")
 sha256sums=('1fcb1df4c92cdf650b85015d41e31d4ae2da43c2c283685d6106f7cfd25ba8e0')


### PR DESCRIPTION
Since version 10.0.0 tinyxml has been replaced by tinyxml2.
See the [changelog](https://github.com/osrf/sdformat/blob/master/Changelog.md#libsdformat-1000-2020-09-28).