### PR TITLE
Fix: ERROR: conflicts is not allowed to be empty.

### DIFF
--- a/yolo-mark-git/PKGBUILD
+++ b/yolo-mark-git/PKGBUILD
@@ -13,7 +13,6 @@ optdepends=()
 makedepends=('cmake' 'git' 'vtk')
 _name=yolo_mark
 provides=('yolo-mark')
-conflicts=('')
 source=("git+https://github.com/AlexeyAB/yolo_mark.git")
 md5sums=('SKIP')
 


### PR DESCRIPTION
Remove `conflicts` clause since this package does not conflict.