### PR TITLE
Add support for c++11 std to fix build error.

### DIFF
--- a/cegui/.SRCINFO
+++ b/cegui/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cegui
 	pkgdesc = A free library providing windowing and widgets for graphics APIs/engines
-	pkgver = 0.8.8
-	pkgrel = 14
+	pkgver = 0.8.7
+	pkgrel = 15
 	url = http://cegui.org.uk
 	arch = i686
 	arch = x86_64
@@ -72,7 +72,7 @@ pkgbase = cegui
 	optdepends = doxygen
 	optdepends = gtk2
 	optdepends = ccache
-	source = cegui-0.8.8::https://github.com/cegui/cegui/archive/v0-8-7.tar.gz
+	source = cegui-0.8.7::https://github.com/cegui/cegui/archive/v0-8-7.tar.gz
 	sha256sums = 7be289d2d8562e7d20bd155d087d6ccb0ba62f7e99cc25d20684b8edf2ba15cd
 
 pkgname = cegui

--- a/cegui/.SRCINFO
+++ b/cegui/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = cegui
 	pkgdesc = A free library providing windowing and widgets for graphics APIs/engines
-	pkgver = 0.8.7
+	pkgver = 0.8.8
 	pkgrel = 14
 	url = http://cegui.org.uk
 	arch = i686
@@ -72,7 +72,7 @@ pkgbase = cegui
 	optdepends = doxygen
 	optdepends = gtk2
 	optdepends = ccache
-	source = cegui-0.8.7::https://github.com/cegui/cegui/archive/v0-8-7.tar.gz
+	source = cegui-0.8.8::https://github.com/cegui/cegui/archive/v0-8-7.tar.gz
 	sha256sums = 7be289d2d8562e7d20bd155d087d6ccb0ba62f7e99cc25d20684b8edf2ba15cd
 
 pkgname = cegui

--- a/cegui/PKGBUILD
+++ b/cegui/PKGBUILD
@@ -7,8 +7,8 @@
 # Contributor: Bjorn Lindeijer <bjorn@lindeijer.nl>
 
 pkgname=cegui
-pkgver=0.8.8
-pkgrel=14
+pkgver=0.8.7
+pkgrel=15
 pkgdesc="A free library providing windowing and widgets for graphics APIs/engines"
 arch=('i686' 'x86_64')
 url="http://cegui.org.uk"

--- a/cegui/PKGBUILD
+++ b/cegui/PKGBUILD
@@ -7,7 +7,7 @@
 # Contributor: Bjorn Lindeijer <bjorn@lindeijer.nl>
 
 pkgname=cegui
-pkgver=0.8.7
+pkgver=0.8.8
 pkgrel=14
 pkgdesc="A free library providing windowing and widgets for graphics APIs/engines"
 arch=('i686' 'x86_64')

--- a/cegui/PKGBUILD
+++ b/cegui/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
+# Contributor: CodeZ <navintiwari08@gmail.com>
 # Contributor: Oskar Sveinsen
 # Contributor: Sven-Hendrik Haase <sh@lutzhaase.com>
 # Contributor: Juergen Hoetzel <juergen@archlinux.org>
@@ -89,6 +90,10 @@ prepare() {
 build() {
   mkdir -p "${srcdir}/${pkgname}-${_pkgver}/build"
   cd "${srcdir}/${pkgname}-${_pkgver}/build"
+  sed -i '1iadd_definitions(-std=c++11)' ../application_templates/CMakeLists.txt
+  sed -i '1iadd_definitions(-std=c++11)' ../samples_framework/CMakeLists.txt
+  sed -i '1iadd_definitions(-std=c++11)' ../cegui/src/RendererModules/OpenGL/CMakeLists.txt
+  sed -i '1iadd_definitions(-std=c++11)' ../cegui/src/ScriptModules/Python/bindings/CMakeLists.txt
 
   cmake -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr \


### PR DESCRIPTION
Closes #133 

Added support for c++11 definitions. Fixes build error on cegui 0.8.7.