### PR TITLE
ogre-1.9: remove versions from provides

### DIFF
--- a/ogre-1.9/PKGBUILD
+++ b/ogre-1.9/PKGBUILD
@@ -13,7 +13,7 @@ depends=('freeimage' 'freetype2' 'libxaw' 'libxrandr' 'openexr'
          'nvidia-cg-toolkit' 'zziplib' 'sdl2' 'glu' 'tinyxml'
          'boost-libs')
 makedepends=('cmake' 'doxygen' 'graphviz' 'ttf-dejavu' 'mesa' 'python' 'swig' 'systemd')
-provides=('ogre=1.9' 'ogre-docs=1.9')
+provides=('ogre' 'ogre-docs')
 source=("https://github.com/OGRECave/ogre/archive/v${pkgver}.tar.gz"
         "sample-comparison-operator-const-args.patch::https://github.com/OGRECave/ogre/commit/4a430a4846d1ea68f669de6b61a72934ac153f7b.patch"
         "sample-comparison-operator-const-callable.patch::https://github.com/OGRECave/ogre/commit/9b1c536b85448ea971822081c7e3c775dbb5cc47.patch"


### PR DESCRIPTION
Ogre doesn't support having different versions installed, so specifying
versions here doesn't work as expected.