### PR TITLE
rewrite recastnagivation PKGBUILD to use same version as debian

### DIFF
--- a/recastnavigation/.SRCINFO
+++ b/recastnavigation/.SRCINFO
@@ -1,18 +1,18 @@
 pkgbase = recastnavigation
-	pkgdesc = Navigation-msh Toolset for Games
-	pkgver = 1.5.1
+	pkgdesc = Navigation-mesh Toolset for Games
+	pkgver = 1.5.1+git20210215.e75adf8
 	pkgrel = 1
+	epoch = 1
 	url = https://github.com/recastnavigation/recastnavigation
 	arch = x86_64
 	license = Zlib
+	makedepends = git
 	makedepends = cmake
-	makedepends = gcc
 	makedepends = sdl2
 	makedepends = glut
-	depends = sdl2
-	depends = glut
-	source = https://github.com/recastnavigation/recastnavigation/archive/1.5.1.tar.gz
-	sha256sums = fdd0d9ac656993cb34d02d3c6c41e3a3311c1da79b84bbedca71c5d629f915fc
+	source = git+https://github.com/recastnavigation/recastnavigation.git#commit=e75adf86f91eb3082220085e42dda62679f9a3ea
+	sha256sums = SKIP
 
 pkgname = recastnavigation
-
+	depends = sdl2
+	depends = glut

--- a/recastnavigation/PKGBUILD
+++ b/recastnavigation/PKGBUILD
@@ -1,26 +1,34 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=recastnavigation
-pkgver=1.5.1
+# since recastnavigation hasn't had an official release in a long time
+# but is now in debian repos maintained by an openmw dev, use debian versioning
+pkgver=1.5.1+git20210215.e75adf8
 pkgrel=1
-pkgdesc="Navigation-msh Toolset for Games"
+epoch=1
+pkgdesc="Navigation-mesh Toolset for Games"
 url="https://github.com/recastnavigation/recastnavigation"
 arch=(x86_64)
 license=('Zlib')
-makedepends=(cmake gcc sdl2 glut)
-depends=(sdl2 glut)
-source=("https://github.com/recastnavigation/recastnavigation/archive/$pkgver.tar.gz")
-sha256sums=("fdd0d9ac656993cb34d02d3c6c41e3a3311c1da79b84bbedca71c5d629f915fc")
+makedepends=(git cmake sdl2 glut)
+source=("git+https://github.com/recastnavigation/recastnavigation.git#commit=e75adf86f91eb3082220085e42dda62679f9a3ea")
+sha256sums=("SKIP")
 
 build() {
-  mkdir -p "$srcdir/${pkgname}-${pkgver}/build"
-  cd "$srcdir/${pkgname}-${pkgver}/build"
-  cmake -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX="$pkgdir/usr" \
-        ..
-  make
+    cmake \
+        -B _build \
+        -S "$srcdir"/recastnavigation  \
+        -D CMAKE_VERBOSE_MAKEFILE=ON \
+        -D CMAKE_BUILD_TYPE=None \
+        -D CMAKE_INSTALL_PREFIX=/usr \
+        -D BUILD_SHARED_LIBS=ON \
+        -D RECASTNAVIGATION_DEMO=OFF \
+		-D RECASTNAVIGATION_TESTS=OFF \
+		-D RECASTNAVIGATION_EXAMPLES=OFF
+    make -C _build
 }
 
 package() {
-  cd "${srcdir}/${pkgname}-${pkgver}/build"
-  make DESDIR=${pkgdir} install
+depends=(sdl2 glut)
+    make DESTDIR="$pkgdir" -C _build install
+    install -Dm644 "$srcdir"/$pkgname/License.txt "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }


### PR DESCRIPTION
Althought recastnavigation hasn't had a release for a long time, an openmw dev has managed to get access to the code, update it and even convinced debian to allow a build from a specfiic git commit.

https://packages.debian.org/source/sid/recastnavigation

This updates recastnavigation to a usable state for openmw (and hopefully other projects).

I am already using this as dependency for my own local openmw git package.

Please update the recastnavigation aur package.

closes #163 