### PR TITLE
go is a build-time dependency only for vgrep, moving go to makedepends

### DIFF
--- a/vgrep/.SRCINFO
+++ b/vgrep/.SRCINFO
@@ -1,12 +1,12 @@
 pkgbase = vgrep
 	pkgdesc = Reimpementation of the ancient cgvg perl scripts
 	pkgver = 2.6.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/vrothberg/vgrep
 	arch = x86_64
 	arch = i686
 	license = GPL3
-	depends = go
+	makedepends = go
 	source = vgrep-2.6.0.tar.gz::https://github.com/vrothberg/vgrep/archive/v2.6.0.tar.gz
 	sha256sums = 4cbd912189397b08897fcc1709787ec60ed42275059f900463055211e1f6d689
 

--- a/vgrep/PKGBUILD
+++ b/vgrep/PKGBUILD
@@ -4,11 +4,11 @@
 
 pkgname=vgrep
 pkgver=2.6.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Reimpementation of the ancient cgvg perl scripts"
 arch=('x86_64' 'i686')
 license=('GPL3')
-depends=('go')
+makedepends=('go')
 url="https://github.com/vrothberg/vgrep"
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/vrothberg/${pkgname}/archive/v${pkgver}.tar.gz")
 sha256sums=('4cbd912189397b08897fcc1709787ec60ed42275059f900463055211e1f6d689')


### PR DESCRIPTION
fixes #177 