### PR TITLE
[QGroundControl] Fix for git's behavioral change.

### DIFF
--- a/qgroundcontrol/PKGBUILD
+++ b/qgroundcontrol/PKGBUILD
@@ -88,7 +88,7 @@ prepare() {
   git config submodule."libs/eigen".url "${srcdir}/${pkgname}"-eigen
   git config submodule."libs/qmdnsengine".url "${srcdir}/${pkgname}"-qmdnsengine
 
-  git submodule update --init --recursive
+  git -c protocol.file.allow=always submodule update --init --recursive
 
   cd "${srcdir}/${pkgname}-${pkgver}/libs/qmlglsink/gst-plugins-good"
   patch --strip=1 < "${srcdir}/gst-volatile.patch"


### PR DESCRIPTION
Git's `protocol.file.allow` is changed to be "user" by default from git v2.38.1, see https://lore.kernel.org/lkml/xmqq4jw1uku5.fsf@gitster.g/

which results in `fatal: transport 'file' not allowed` when initializing submodules. The added `-c protocol.file.allow=always` option fixes this.