### PR TITLE
Fix RapidXml source URL

### DIFF
--- a/rapidxml/PKGBUILD
+++ b/rapidxml/PKGBUILD
@@ -8,7 +8,7 @@ url=""
 license=('Boost/MIT')
 provides=("rapidxml")
 _pkgname="RapidXml"
-source=("git://github.com/hydranix/RapidXml"
+source=("git+https://github.com/hydranix/RapidXml"
         "0001-fix-for-a-bug-in-gcc-that-won-t-let-rapidxml-compile.patch")
 
 md5sums=('SKIP'


### PR DESCRIPTION
Updates source URL for RapidXML PKGBUILD as according to [this comment](https://aur.archlinux.org/packages/rapidxml#comment-857991).

This change is required because the unauthenticated git protocol on port 9418 is no longer supported, so the current build fails without this fix.