### PR TITLE
[python-hydra-core] Fix antlr4 runtime version

### DIFF
--- a/python-hydra-core/.SRCINFO
+++ b/python-hydra-core/.SRCINFO
@@ -1,10 +1,11 @@
 pkgbase = python-hydra-core
 	pkgdesc = A framework for elegantly configuring complex applications
-	pkgver = 1.2.0
+	pkgver = 1.3.1
 	pkgrel = 1
 	url = https://hydra.cc
 	arch = any
 	license = MIT
+	makedepends = antlr4
 	makedepends = python
 	makedepends = python-build
 	makedepends = python-installer
@@ -14,7 +15,9 @@ pkgbase = python-hydra-core
 	depends = python-omegaconf
 	depends = python-antlr4
 	depends = java-environment
-	source = python-hydra-core-1.2.0::https://github.com/facebookresearch/hydra/archive/refs/tags/v1.2.0.tar.gz
-	sha256sums = 19b203fc614426cd6e4bb7c51e73a25a1ceb4606450ec0203345aec67a0a4f6a
+	source = python-hydra-core-1.3.1::https://github.com/facebookresearch/hydra/archive/refs/tags/v1.3.1.tar.gz
+	source = antlr4-jar.patch
+	sha256sums = 9ba1efe09893853e883498fcbeec17f2a77e1ba551587d6d0604077e02de1602
+	sha256sums = 9db3a15d9c32cc754d19efbe0065025612ed6cd0d68d948ccebd5dc6544aadc6
 
 pkgname = python-hydra-core

--- a/python-hydra-core/PKGBUILD
+++ b/python-hydra-core/PKGBUILD
@@ -4,19 +4,26 @@
 # Contributor: Andrei Shadrikov <notvuvko@gmail.com>
 
 pkgname='python-hydra-core'
-pkgver='1.2.0'
+pkgver='1.3.1'
 pkgrel=1
 pkgdesc='A framework for elegantly configuring complex applications'
 arch=('any')
 url='https://hydra.cc'
 license=('MIT')
 depends=('python-omegaconf' 'python-antlr4' 'java-environment')
-makedepends=('python' 'python-build' 'python-installer' 'python-wheel'
+makedepends=('antlr4' 'java-runtime>=11', 'python' 'python-build' 'python-installer' 'python-wheel'
              'python-setuptools' 'python-packaging')
-source=("$pkgname-$pkgver::https://github.com/facebookresearch/hydra/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('19b203fc614426cd6e4bb7c51e73a25a1ceb4606450ec0203345aec67a0a4f6a')
+source=("$pkgname-$pkgver::https://github.com/facebookresearch/hydra/archive/refs/tags/v${pkgver}.tar.gz"
+        "antlr4-jar.patch")
+sha256sums=('9ba1efe09893853e883498fcbeec17f2a77e1ba551587d6d0604077e02de1602'
+            '9db3a15d9c32cc754d19efbe0065025612ed6cd0d68d948ccebd5dc6544aadc6')
 
 _pkgname=hydra
+
+prepare() {
+    pwd
+	patch -p1 -d "$_pkgname-$pkgver" < antlr4-jar.patch
+}
 
 build() {
   cd "${srcdir}/${_pkgname}-${pkgver}"

--- a/python-hydra-core/antlr4-jar.patch
+++ b/python-hydra-core/antlr4-jar.patch
@@ -1,0 +1,13 @@
+diff --git a/build_helpers/build_helpers.py b/build_helpers/build_helpers.py
+index 7159d22615..8401fee3b7 100644
+--- a/build_helpers/build_helpers.py
++++ b/build_helpers/build_helpers.py
+@@ -185,7 +185,7 @@ class ANTLRCommand(Command):  # type: ignore
+             command = [
+                 "java",
+                 "-jar",
+-                join(root_dir, "bin/antlr-4.9.3-complete.jar"),
++                "/usr/share/java/antlr-complete.jar",
+                 "-Dlanguage=Python3",
+                 "-o",
+                 join(project_root, "hydra/grammar/gen/"),


### PR DESCRIPTION
Maybe, some auxiliary constrains on java runtime are needed in advance.

https://aur.archlinux.org/packages/python-hydra-core