### PR TITLE
[mpir] add dependency on automake

### DIFF
--- a/mpir/PKGBUILD
+++ b/mpir/PKGBUILD
@@ -10,7 +10,8 @@ arch=('i686' 'x86_64' 'aarch64')
 url="https://www.mpir.org/"
 license=('LGPL')
 depends=('gcc-libs')
-makedepends=('yasm')
+makedepends=('yasm'
+             'automake')
 source=("$pkgname-$pkgver.tar.gz::https://www.github.com/wbhart/mpir/archive/refs/tags/mpir-$pkgver.tar.gz"
         "get_d.patch::https://patch-diff.githubusercontent.com/raw/wbhart/mpir/pull/296.patch")
 sha256sums=('86a5039badc3e6738219a262873a1db5513405e15ece9527b718fcd0fac09bb2'


### PR DESCRIPTION
mpir requires aclocal to be built; I was getting the error 'can't run aclocal' and fixed it by installing automake, so it looks like it should be added as a make dependency