### PR TITLE
Fix - Python Vispy checksum

### DIFF
--- a/python-vispy/.SRCINFO
+++ b/python-vispy/.SRCINFO
@@ -13,7 +13,6 @@ pkgbase = python-vispy
 	makedepends = python-numpy
 	makedepends = cython
 	makedepends = python-setuptools-scm
-	makedepends = python-setuptools-scm-git-archive
 	makedepends = npm
 	makedepends = python-oldest-supported-numpy
 	depends = python-numpy

--- a/python-vispy/.SRCINFO
+++ b/python-vispy/.SRCINFO
@@ -29,6 +29,6 @@ pkgbase = python-vispy
 	optdepends = python-pysdl2: sdl2
 	optdepends = python-wxpython: wx
 	source = python-vispy-0.13.0.tar.gz::https://github.com/vispy/vispy/archive/v0.13.0.tar.gz
-	sha256sums = 773c3e336e6cabfc81163abd49887994013d040643e85a7fd7c6932699e482ae
+	sha256sums = c621d3edf7dff445ebaff2fbece244db77db821e2e0c0e59c83ea9cc6666d99e
 
 pkgname = python-vispy

--- a/python-vispy/PKGBUILD
+++ b/python-vispy/PKGBUILD
@@ -12,7 +12,7 @@ license=('BSD')
 depends=('python-numpy' 'python-freetype-py' 'python-hsluv' 'python-kiwisolver')
 makedepends=('python' 'python-build' 'python-installer' 'python-wheel'
              'python-setuptools' 'python-numpy' 'cython' 'python-setuptools-scm'
-             'python-setuptools-scm-git-archive' 'npm'
+             'npm'
              'python-oldest-supported-numpy')
 optdepends=('ipython: ipython-static'
             'python-pyglet: pyglet'
@@ -28,6 +28,8 @@ sha256sums=('c621d3edf7dff445ebaff2fbece244db77db821e2e0c0e59c83ea9cc6666d99e')
 
 build() {
     cd "$srcdir/${_pkgname}-${pkgver}"
+    sed -i "s/'setuptools_scm_git_archive',//g" setup.py
+    sed -i 's/"setuptools_scm_git_archive",//g' pyproject.toml
     python -m build --wheel --no-isolation
 }
 

--- a/python-vispy/PKGBUILD
+++ b/python-vispy/PKGBUILD
@@ -24,7 +24,7 @@ optdepends=('ipython: ipython-static'
             'python-wxpython: wx')
 _pkgname=vispy
 source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/vispy/vispy/archive/v$pkgver.tar.gz")
-sha256sums=('773c3e336e6cabfc81163abd49887994013d040643e85a7fd7c6932699e482ae')
+sha256sums=('c621d3edf7dff445ebaff2fbece244db77db821e2e0c0e59c83ea9cc6666d99e')
 
 build() {
     cd "$srcdir/${_pkgname}-${pkgver}"


### PR DESCRIPTION
This pr fixes wrong checksum
The package still fails to build after this because #221
And the package https://aur.archlinux.org/packages/python-setuptools-scm-git-archive is orphan

I'm gonna make another pr to try fix that