### PR TITLE
[matplotplusplus] Update to 1.2.0

### DIFF
--- a/matplotplusplus/.SRCINFO
+++ b/matplotplusplus/.SRCINFO
@@ -1,13 +1,13 @@
 pkgbase = matplotplusplus
 	pkgdesc = Matplot++: A C++ Graphics Library for Data Visualization
-	pkgver = 1.1.0
+	pkgver = 1.2.0
 	pkgrel = 1
-	url = https://alandefreitas.github.io/matplotplusplus/
+	url = https://alandefreitas.github.io/matplotplusplus
 	arch = x86_64
 	license = MIT
 	makedepends = cmake
 	depends = gnuplot
-	source = matplotplusplus-1.1.0.tar.gz::https://github.com/alandefreitas/matplotplusplus/archive/v1.1.0.tar.gz
-	sha256sums = 5c3a1bdfee12f5c11fd194361040fe4760f57e334523ac125ec22b2cb03f27bb
+	source = matplotplusplus-1.2.0.tar.gz::https://github.com/alandefreitas/matplotplusplus/archive/v1.2.0.tar.gz
+	sha256sums = 42e24edf717741fcc721242aaa1fdb44e510fbdce4032cdb101c2258761b2554
 
 pkgname = matplotplusplus

--- a/matplotplusplus/PKGBUILD
+++ b/matplotplusplus/PKGBUILD
@@ -1,15 +1,15 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=matplotplusplus
-pkgver=1.1.0
+pkgver=1.2.0
 pkgrel=1
 pkgdesc="Matplot++: A C++ Graphics Library for Data Visualization"
-url="https://alandefreitas.github.io/matplotplusplus/"
+url="https://alandefreitas.github.io/matplotplusplus"
 arch=(x86_64)
 license=('MIT')
 makedepends=(cmake)
 depends=(gnuplot)
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/alandefreitas/matplotplusplus/archive/v$pkgver.tar.gz")
-sha256sums=("5c3a1bdfee12f5c11fd194361040fe4760f57e334523ac125ec22b2cb03f27bb")
+sha256sums=('42e24edf717741fcc721242aaa1fdb44e510fbdce4032cdb101c2258761b2554')
 
 build() {
   mkdir -p "$srcdir/${pkgname}-${pkgver}/build"


### PR DESCRIPTION
With this upgrade, fixes gcc-13 compatibility. Today, the package can not build with the old version.