### PR TITLE
Fix checksum for python-vispy

### DIFF
--- a/python-vispy/.SRCINFO
+++ b/python-vispy/.SRCINFO
@@ -29,6 +29,6 @@ pkgbase = python-vispy
 	optdepends = python-meshio: io
 	optdepends = python-pillow: io
 	source = python-vispy-0.14.0.tar.gz::https://github.com/vispy/vispy/archive/v0.14.0.tar.gz
-	sha256sums = 87d99d85377ebbedec78f8358840a209690ee783ee6e8ca65ed5ef99f783e4c3
+	sha256sums = dd26129b8900c25e265e07fca701e7dffde0fbb52c91f290a7b570532983c9e3
 
 pkgname = python-vispy

--- a/python-vispy/PKGBUILD
+++ b/python-vispy/PKGBUILD
@@ -25,7 +25,7 @@ optdepends=('ipython: ipython-static'
             'python-pillow: io')
 _pkgname=vispy
 source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/vispy/vispy/archive/v$pkgver.tar.gz")
-sha256sums=('87d99d85377ebbedec78f8358840a209690ee783ee6e8ca65ed5ef99f783e4c3')
+sha256sums=('dd26129b8900c25e265e07fca701e7dffde0fbb52c91f290a7b570532983c9e3')
 
 build() {
     cd "$srcdir/${_pkgname}-${pkgver}"


### PR DESCRIPTION
Otherwise we will have the following error.

![image](https://github.com/acxz/pkgbuilds/assets/21283014/aecfae0c-0476-4d3b-8f4a-f4ae1ed8e371)
