### PR TITLE
install PyKDL to site-packages instead and update octomap to 1.10.0

### DIFF
--- a/octomap/.SRCINFO
+++ b/octomap/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = octomap
 	pkgdesc = Efficient probabilistic 3D mapping framework based on octrees
-	pkgver = 1.9.8
+	pkgver = 1.10.0
 	pkgrel = 1
 	url = https://octomap.github.io/
 	arch = i686
@@ -11,7 +11,7 @@ pkgbase = octomap
 	provides = octomap
 	conflicts = octomap-git
 	options = staticlibs
-	source = octomap-1.9.8.tar.gz::https://github.com/OctoMap/octomap/archive/v1.9.8.tar.gz
+	source = octomap-1.10.0.tar.gz::https://github.com/OctoMap/octomap/archive/v1.10.0.tar.gz
 	source = iterator.patch::https://patch-diff.githubusercontent.com/raw/OctoMap/octomap/pull/373.patch
 	sha256sums = 417af6da4e855e9a83b93458aa98b01a2c88f880088baad2b59d323ce162586e
 	sha256sums = SKIP

--- a/octomap/PKGBUILD
+++ b/octomap/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Soo-Hyun Yoo <yoos117 at gmail dot com>
 
 pkgname=octomap
-pkgver=1.9.8
+pkgver=1.10.0
 pkgrel=1
 pkgdesc="Efficient probabilistic 3D mapping framework based on octrees"
 arch=('i686' 'x86_64')
@@ -15,15 +15,8 @@ makedepends=('cmake')
 provides=('octomap')
 conflicts=('octomap-git')
 options=('staticlibs')
-source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/OctoMap/octomap/archive/v${pkgver}.tar.gz"
-        "iterator.patch::https://patch-diff.githubusercontent.com/raw/OctoMap/octomap/pull/373.patch")
-sha256sums=('417af6da4e855e9a83b93458aa98b01a2c88f880088baad2b59d323ce162586e'
-            'SKIP')
-
-prepare() {
-    cd "$srcdir/octomap-$pkgver"
-    patch -Np1 -i "$srcdir/iterator.patch"
-}
+source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/OctoMap/octomap/archive/v${pkgver}.tar.gz")
+sha256sums=('8da2576ec6a0993e8900db7f91083be8682d8397a7be0752c85d1b7dd1b8e992')
 
 build() {
     cd "$srcdir/octomap-$pkgver/octomap"

--- a/orocos-kdl-python/.SRCINFO
+++ b/orocos-kdl-python/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = orocos-kdl-python
 	pkgdesc = The Kinematics and Dynamics Library is a framework for modelling and computation of kinematic chains (Python binding)
 	pkgver = 1.5.1
-	pkgrel = 2
+	pkgrel = 3
 	url = https://www.orocos.org/kdl
 	arch = i686
 	arch = x86_64

--- a/orocos-kdl-python/PKGBUILD
+++ b/orocos-kdl-python/PKGBUILD
@@ -5,7 +5,7 @@ pkgname=orocos-kdl-python
 _dir=orocos_kinematics_dynamics
 _pkgname=python_orocos_kdl
 pkgver=1.5.1
-pkgrel=2
+pkgrel=3
 pkgdesc="The Kinematics and Dynamics Library is a framework for modelling and computation of kinematic chains (Python binding)"
 arch=('i686' 'x86_64')
 url="https://www.orocos.org/kdl"
@@ -28,6 +28,9 @@ prepare() {
   # Copy in the pybind11 source
   rm -rf "${srcdir}/${_dir}-${pkgver}/${_pkgname}/pybind11"
   cp -R "${srcdir}/${pybinddir}" "${srcdir}/${_dir}-${pkgver}/${_pkgname}/pybind11"
+
+  # Install to site-packages instead of dist-packages
+  sed -i "s|dist-packages|site-packages|" ${srcdir}/${_dir}-${pkgver}/${_pkgname}/CMakeLists.txt
 }
 
 build() {


### PR DESCRIPTION
`PyKDL` is used by `tf2-sensor-msgs`. `dist-packages` is not included in the `sys.path` by default. It is recommended to use `site-packages` instead. `site-packages` is used when building this package with ROS activated.