### PR TITLE
[octomap+libccd] Fix ciso646 and cmake version issues (fix #288)

### DIFF
--- a/libccd/PKGBUILD
+++ b/libccd/PKGBUILD
@@ -23,6 +23,7 @@ build() {
   cmake ${srcdir}/${_dir} \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_INSTALL_LIBDIR=lib \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     -DCMAKE_BUILD_TYPE=Release
 
   make

--- a/octomap/PKGBUILD
+++ b/octomap/PKGBUILD
@@ -15,8 +15,18 @@ makedepends=('cmake')
 provides=('octomap')
 conflicts=('octomap-git')
 options=('staticlibs')
-source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/OctoMap/octomap/archive/v${pkgver}.tar.gz")
-sha256sums=('8da2576ec6a0993e8900db7f91083be8682d8397a7be0752c85d1b7dd1b8e992')
+source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/OctoMap/octomap/archive/v${pkgver}.tar.gz"
+        "fix-ciso646-header.patch"
+        "fix-cmake-version.patch")
+sha256sums=('8da2576ec6a0993e8900db7f91083be8682d8397a7be0752c85d1b7dd1b8e992'
+            'SKIP'
+            'SKIP')
+
+prepare() {
+    cd "$srcdir/octomap-$pkgver"
+    patch -Np1 -i ../fix-ciso646-header.patch
+    patch -Np1 -i ../fix-cmake-version.patch
+}
 
 build() {
     cd "$srcdir/octomap-$pkgver/octomap"

--- a/octomap/fix-ciso646-header.patch
+++ b/octomap/fix-ciso646-header.patch
@@ -1,0 +1,24 @@
+diff -ura octomap-1.10.0.orig/octomap/include/octomap/OcTreeKey.h octomap-1.10.0.new/octomap/include/octomap/OcTreeKey.h
+--- octomap-1.10.0.orig/octomap/include/octomap/OcTreeKey.h	2025-07-04 12:46:08.736803128 +0200
++++ octomap-1.10.0.new/octomap/include/octomap/OcTreeKey.h	2025-07-04 12:41:52.669078078 +0200
+@@ -37,7 +37,7 @@
+ /* According to c++ standard including this header has no practical effect
+  * but it can be used to determine the c++ standard library implementation.
+  */
+-#include <ciso646>
++#include <version>
+ 
+ #include <assert.h>
+ 
+diff -ura octomap-1.10.0.orig/octomap/src/Pointcloud.cpp octomap-1.10.0.new/octomap/src/Pointcloud.cpp
+--- octomap-1.10.0.orig/octomap/src/Pointcloud.cpp	2025-07-04 12:46:08.738439105 +0200
++++ octomap-1.10.0.new/octomap/src/Pointcloud.cpp	2025-07-04 12:41:53.310878043 +0200
+@@ -34,7 +34,7 @@
+ /* According to c++ standard including this header has no practical effect
+  * but it can be used to determine the c++ standard library implementation.
+  */ 
+-#include <ciso646>
++#include <version>
+ 
+ #if defined(_MSC_VER) || defined(_LIBCPP_VERSION)
+   #include <algorithm>

--- a/octomap/fix-cmake-version.patch
+++ b/octomap/fix-cmake-version.patch
@@ -1,0 +1,9 @@
+diff -ura octomap-1.10.0.orig/CMakeLists.txt octomap-1.10.0.new/CMakeLists.txt
+--- octomap-1.10.0.orig/CMakeLists.txt	2025-07-04 12:46:08.734930419 +0200
++++ octomap-1.10.0.new/CMakeLists.txt	2025-07-04 12:45:01.142613588 +0200
+@@ -1,4 +1,4 @@
+-CMAKE_MINIMUM_REQUIRED(VERSION 3.0.2)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
+ PROJECT( octomap-distribution )
+ 
+ ENABLE_TESTING()  # enable CTest environment of subprojects


### PR DESCRIPTION
Fixes #288 and a similar issue for libccd.

Octomap has [fixed](https://github.com/OctoMap/octomap/commit/79cd7fddd3d0b7448e2a1ee0524ca89b292485d3) the cmake version issue, but that fix isn't released yet.